### PR TITLE
Enable setting a custom ALLOWED_ORIGIN

### DIFF
--- a/server/dist/setup/middleware.js
+++ b/server/dist/setup/middleware.js
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import logger from '../logger.js';
 import os from 'os';
+const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN;
 function getLocalIp() {
     const interfaces = os.networkInterfaces();
     for (const interfaceName in interfaces) {
@@ -36,7 +37,8 @@ export default function (app) {
                 origin?.startsWith('http://localhost') ||
                 origin?.startsWith('http://192.168.') ||
                 origin?.startsWith('http://172.16.') ||
-                origin?.startsWith('http://10.0.')) {
+                origin?.startsWith('http://10.0.') ||
+                (ALLOWED_ORIGIN && origin?.startsWith(ALLOWED_ORIGIN))) {
                 callback(null, true);
             }
             else {

--- a/server/src/setup/middleware.ts
+++ b/server/src/setup/middleware.ts
@@ -4,6 +4,7 @@ import logger from '../logger.js';
 
 import os from 'os';
 
+const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN;
 
 function getLocalIp(): string {
   const interfaces = os.networkInterfaces();
@@ -47,7 +48,8 @@ export default function (app: Express) {
           origin?.startsWith('http://localhost') ||
           origin?.startsWith('http://192.168.') ||
           origin?.startsWith('http://172.16.') ||
-          origin?.startsWith('http://10.0.')
+          origin?.startsWith('http://10.0.') ||
+          (ALLOWED_ORIGIN && origin?.startsWith(ALLOWED_ORIGIN))
         ) {
           callback(null, true);
         } else {


### PR DESCRIPTION
Allow setting a custom allowed origin if desired.

Personally, I keep my eight sleep is behind a reverse proxy on it's own VLAN.