### PR TITLE
Fix minor shell escaping typo in setup_ssh.sh

### DIFF
--- a/scripts/setup_ssh.sh
+++ b/scripts/setup_ssh.sh
@@ -94,5 +94,5 @@ systemctl status sshd.service --no-pager
 echo ""
 echo "SSH service setup complete!"
 echo "SSH uses port 8822!"
-echo "SSH into your device with `ssh root@<IP> -p 8822`"
+echo "SSH into your device with \`ssh root@<IP> -p 8822\`"
 echo ""


### PR DESCRIPTION
Without this, bash tries (and fails) to execute the example command inline, creating an error instead of the helpful output it should generate.