### PR TITLE
Allow to use native temperature level in backend

### DIFF
--- a/server/dist/8sleep/loadDeviceStatus.js
+++ b/server/dist/8sleep/loadDeviceStatus.js
@@ -69,14 +69,18 @@ export async function loadDeviceStatus(response) {
     await memoryDB.read();
     return {
         left: {
+            currentTemperatureLevel: Number.parseInt(rawDeviceData.heatLevelL, 10),
             currentTemperatureF: calculateTempInF(rawDeviceData.heatLevelL),
+            targetTemperatureLevel: Number.parseInt(rawDeviceData.tgHeatLevelL, 10),
             targetTemperatureF: calculateTempInF(rawDeviceData.tgHeatLevelL),
             secondsRemaining: leftSideSecondsRemaining,
             isOn: leftSideSecondsRemaining > 0,
             isAlarmVibrating: memoryDB.data.left.isAlarmVibrating,
         },
         right: {
+            currentTemperatureLevel: Number.parseInt(rawDeviceData.heatLevelR, 10),
             currentTemperatureF: calculateTempInF(rawDeviceData.heatLevelR),
+            targetTemperatureLevel: Number.parseInt(rawDeviceData.tgHeatLevelR, 10),
             targetTemperatureF: calculateTempInF(rawDeviceData.tgHeatLevelR),
             secondsRemaining: rightSideSecondsRemaining,
             isOn: rightSideSecondsRemaining > 0,

--- a/server/dist/routes/deviceStatus/deviceStatusSchema.js
+++ b/server/dist/routes/deviceStatus/deviceStatusSchema.js
@@ -1,7 +1,11 @@
 // WARNING! - Any changes here MUST be the same between app/src/api & server/src/db/
 import { z } from 'zod';
 const SideStatusSchema = z.object({
+    currentTemperatureLevel: z.number(),
     currentTemperatureF: z.number(),
+    targetTemperatureLevel: z.number()
+        .min(-100, { message: 'targetTemperatureLevel must be at least -100' })
+        .max(100, { message: 'targetTemperatureLevel cannot exceed 100' }),
     targetTemperatureF: z.number()
         .min(55, { message: 'Temperature must be at least 55°F' })
         .max(110, { message: 'Temperature cannot exceed 110°F' }),

--- a/server/dist/routes/deviceStatus/updateDeviceStatus.js
+++ b/server/dist/routes/deviceStatus/updateDeviceStatus.js
@@ -25,7 +25,7 @@ const updateSide = async (side, sideStatus) => {
     const controlBothSides = settings.left.awayMode || settings.right.awayMode;
     const updateLeft = side === 'left' || controlBothSides;
     const updateRight = side === 'right' || controlBothSides;
-    const { isOn, targetTemperatureF, secondsRemaining, isAlarmVibrating } = sideStatus;
+    const { isOn, targetTemperatureLevel, targetTemperatureF, secondsRemaining, isAlarmVibrating } = sideStatus;
     if (controlBothSides) {
         logger.debug('One side is in away mode, updating both sides...');
     }
@@ -36,7 +36,13 @@ const updateSide = async (side, sideStatus) => {
         if (updateRight)
             await executeFunction('RIGHT_TEMP_DURATION', onDuration);
     }
-    if (targetTemperatureF) {
+    if (targetTemperatureLevel) {
+        if (updateLeft)
+            await executeFunction('TEMP_LEVEL_LEFT', targetTemperatureLevel.toString());
+        if (updateRight)
+            await executeFunction('TEMP_LEVEL_RIGHT', targetTemperatureLevel.toString());
+    }
+    else if (targetTemperatureF) {
         const level = calculateLevelFromF(targetTemperatureF);
         if (updateLeft)
             await executeFunction('TEMP_LEVEL_LEFT', level);

--- a/server/src/8sleep/loadDeviceStatus.ts
+++ b/server/src/8sleep/loadDeviceStatus.ts
@@ -78,14 +78,18 @@ export async function loadDeviceStatus(response: string): Promise<DeviceStatus> 
 
   return {
     left: {
+      currentTemperatureLevel: Number.parseInt(rawDeviceData.heatLevelL, 10),
       currentTemperatureF: calculateTempInF(rawDeviceData.heatLevelL),
+      targetTemperatureLevel: Number.parseInt(rawDeviceData.tgHeatLevelL, 10),
       targetTemperatureF: calculateTempInF(rawDeviceData.tgHeatLevelL),
       secondsRemaining: leftSideSecondsRemaining,
       isOn: leftSideSecondsRemaining > 0,
       isAlarmVibrating: memoryDB.data.left.isAlarmVibrating,
     },
     right: {
+      currentTemperatureLevel: Number.parseInt(rawDeviceData.heatLevelR, 10),
       currentTemperatureF: calculateTempInF(rawDeviceData.heatLevelR),
+      targetTemperatureLevel: Number.parseInt(rawDeviceData.tgHeatLevelR, 10),
       targetTemperatureF: calculateTempInF(rawDeviceData.tgHeatLevelR),
       secondsRemaining: rightSideSecondsRemaining,
       isOn: rightSideSecondsRemaining > 0,

--- a/server/src/routes/deviceStatus/deviceStatusSchema.ts
+++ b/server/src/routes/deviceStatus/deviceStatusSchema.ts
@@ -3,7 +3,11 @@
 import { z } from 'zod';
 
 const SideStatusSchema = z.object({
+  currentTemperatureLevel: z.number(),
   currentTemperatureF: z.number(),
+  targetTemperatureLevel: z.number()
+    .min(-100, { message: 'targetTemperatureLevel must be at least -100' })
+    .max(100, { message: 'targetTemperatureLevel cannot exceed 100' }),
   targetTemperatureF: z.number()
     .min(55, { message: 'Temperature must be at least 55°F' })
     .max(110, { message: 'Temperature cannot exceed 110°F' }),

--- a/server/src/routes/deviceStatus/updateDeviceStatus.ts
+++ b/server/src/routes/deviceStatus/updateDeviceStatus.ts
@@ -30,7 +30,7 @@ const updateSide = async (side: 'left' | 'right', sideStatus: DeepPartial<SideSt
   const updateLeft = side === 'left' || controlBothSides;
   const updateRight = side === 'right' || controlBothSides;
 
-  const { isOn, targetTemperatureF, secondsRemaining, isAlarmVibrating } = sideStatus;
+  const { isOn, targetTemperatureLevel, targetTemperatureF, secondsRemaining, isAlarmVibrating } = sideStatus;
 
   if (controlBothSides) {
     logger.debug('One side is in away mode, updating both sides...');
@@ -42,7 +42,10 @@ const updateSide = async (side: 'left' | 'right', sideStatus: DeepPartial<SideSt
     if (updateRight) await executeFunction('RIGHT_TEMP_DURATION', onDuration);
   }
 
-  if (targetTemperatureF) {
+  if (targetTemperatureLevel) {
+    if (updateLeft) await executeFunction('TEMP_LEVEL_LEFT', targetTemperatureLevel.toString());
+    if (updateRight) await executeFunction('TEMP_LEVEL_RIGHT', targetTemperatureLevel.toString());
+  } else if (targetTemperatureF) {
     const level = calculateLevelFromF(targetTemperatureF);
     if (updateLeft) await executeFunction('TEMP_LEVEL_LEFT', level);
     if (updateRight) await executeFunction('TEMP_LEVEL_RIGHT', level);


### PR DESCRIPTION
Natively, the system works with temperature levels ranging from -100 to +100. The free-sleep implementation is based on degrees Fahrenheit, which always involves conversions. This pull request allows to set and fetch the native temperature levels, but it does not restrict the backend to it. This is still completely compatible with the previous behavior. It only adds backend support for the native levels.

I'm using this myself with home assistant for 3 months now (HA sending REST requests in automations) and for my use case, it works just fine. Maybe there's someone else out there who wants to use the levels, too.

Thanks for the good work with this project! I'm absolutely loving it!

I'm happy to make adjustments if needed.