### PR TITLE
Properly log unhandled error messages

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -145,7 +145,7 @@ async function startServer() {
     await gracefulShutdown('uncaughtException');
   });
   process.on('unhandledRejection', async (reason, promise) => {
-    logger.error('Unhandled Rejection at:', promise, 'reason:', reason);
+    logger.error(`Unhandled Rejection at: ${promise}, reason: ${reason}`);
     await gracefulShutdown('unhandledRejection');
   });
 }


### PR DESCRIPTION
Before this error messages would show up as `| error | Unhandled Rejection at:` without the actual error message.