### PR TITLE
Fix sleep analyzer loading only 1% of piezo data

### DIFF
--- a/biometrics/load_raw_files.py
+++ b/biometrics/load_raw_files.py
@@ -77,6 +77,9 @@ def _decode_cbor_file(file_path: str, data: dict, start_time, end_time, side: Si
 
                 # Decode the next CBOR object
                 row = cbor2.load(raw_data)
+                # Skip records with empty data (malformed records)
+                if not row.get('data'):
+                    continue
                 decoded_data = cbor2.loads(row['data'])
                 if not decoded_data['type'] in load_raw_types:
                     continue


### PR DESCRIPTION
## Summary
- Fix CBOR file reading loop exiting early when encountering records with empty data fields
- This was causing sleep analyzer to load only ~250 records instead of ~46,000 per night

## Root Cause
1. Some RAW files contain records with `data: b''` (empty byte string)
2. When `cbor2.loads(b'')` is called, it raises `CBORDecodeEOF`
3. `CBORDecodeEOF` inherits from `EOFError`
4. The `except EOFError: break` handler catches this, exiting the loop prematurely

## Fix
Skip records with empty data before attempting to decode.

## Test plan
- [x] Verified fix loads 900 piezo-dual records (previously 6) from a single RAW file
- [x] Verified fix loads all expected records for a full night's data
- [ ] Deploy to device and verify sleep detection works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)