### PR TITLE
Fix biometrics on Pod 5: cbor2 C extension skips records + empty placeholder records break read loop

### DIFF
--- a/biometrics/load_raw_files.py
+++ b/biometrics/load_raw_files.py
@@ -1,3 +1,4 @@
+import struct
 import numpy as np
 import traceback
 from datetime import datetime, timedelta, timezone
@@ -13,6 +14,75 @@ from data_types import *
 from get_logger import get_logger
 
 logger = get_logger()
+
+
+def _read_raw_record(f):
+    """
+    Manually parse one outer {seq, data} CBOR record using f.read().
+
+    The cbor2 C extension (_cbor2) reads files in internal 4096-byte chunks,
+    so cbor2.load(f) advances f.tell() by 4096 bytes regardless of the actual
+    record size. Since RAW file records are typically 17-5000 bytes, this causes
+    nearly every record to be skipped silently.
+
+    This function parses the outer {seq: uint, data: bytes} wrapper byte-by-byte
+    using f.read(), keeping f.tell() accurate after each record.
+
+    Returns the raw inner data bytes, or None for empty placeholder records
+    (which the Pod firmware writes as sequence number markers with data=b'').
+    Raises EOFError at end of file, ValueError on malformed data.
+    """
+    b = f.read(1)
+    if not b:
+        raise EOFError
+    if b[0] != 0xa2:
+        raise ValueError('Expected outer map 0xa2, got 0x%02x' % b[0])
+    if f.read(4) != b'\x63\x73\x65\x71':
+        raise ValueError('Expected seq key')
+    hdr = f.read(1)
+    if not hdr:
+        raise EOFError
+    if hdr[0] == 0x1a:
+        seq_bytes = f.read(4)
+        if len(seq_bytes) < 4:
+            raise EOFError
+    elif hdr[0] == 0x1b:
+        seq_bytes = f.read(8)
+        if len(seq_bytes) < 8:
+            raise EOFError
+    else:
+        raise ValueError('Unexpected seq encoding: 0x%02x' % hdr[0])
+    if f.read(5) != b'\x64\x64\x61\x74\x61':
+        raise ValueError('Expected data key')
+    bs = f.read(1)
+    if not bs:
+        raise EOFError
+    ai = bs[0] & 0x1f
+    if ai <= 23:
+        length = ai
+    elif ai == 24:
+        lb = f.read(1)
+        if not lb:
+            raise EOFError
+        length = lb[0]
+    elif ai == 25:
+        lb = f.read(2)
+        if len(lb) < 2:
+            raise EOFError
+        length = struct.unpack('>H', lb)[0]
+    elif ai == 26:
+        lb = f.read(4)
+        if len(lb) < 4:
+            raise EOFError
+        length = struct.unpack('>I', lb)[0]
+    else:
+        raise ValueError('Unsupported length encoding: %d' % ai)
+    data = f.read(length)
+    if len(data) < length:
+        raise EOFError
+    if not data:
+        return None  # empty placeholder record, caller should skip
+    return data
 
 
 def get_current_files(folder_path: str):
@@ -75,9 +145,13 @@ def _decode_cbor_file(file_path: str, data: dict, start_time, end_time, side: Si
         while True:
             try:
 
-                # Decode the next CBOR object
-                row = cbor2.load(raw_data)
-                decoded_data = cbor2.loads(row['data'])
+                # Use manual reader instead of cbor2.load() to avoid the cbor2
+                # C extension reading in 4096-byte chunks, which causes it to
+                # skip most records regardless of their actual size.
+                data_bytes = _read_raw_record(raw_data)
+                if data_bytes is None:
+                    continue  # empty placeholder record
+                decoded_data = cbor2.loads(data_bytes)
                 if not decoded_data['type'] in load_raw_types:
                     continue
                 _delete_other_side(decoded_data, side, sensor_count)

--- a/biometrics/stream/stream.py
+++ b/biometrics/stream/stream.py
@@ -19,6 +19,7 @@ This is set up to run as a systemctl service, but you can manually run it with:
 
 import sys
 import platform
+import struct
 import cbor2
 from datetime import datetime, timedelta
 
@@ -45,6 +46,75 @@ from service_health import update_health
 
 # Global queue for processing decoded biometric data
 piezo_record_queue = queue.Queue()
+
+
+def _read_raw_record(f):
+    """
+    Manually parse one outer {seq, data} CBOR record using f.read().
+
+    The cbor2 C extension (_cbor2) reads files in internal 4096-byte chunks,
+    so cbor2.load(f) advances f.tell() by 4096 bytes regardless of the actual
+    record size. Since RAW file records are typically 17-5000 bytes, this causes
+    nearly every record to be skipped silently.
+
+    This function parses the outer {seq: uint, data: bytes} wrapper byte-by-byte
+    using f.read(), keeping f.tell() accurate after each record.
+
+    Returns the raw inner data bytes, or None for empty placeholder records
+    (which the Pod firmware writes as sequence number markers with data=b'').
+    Raises EOFError at end of file, ValueError on malformed data.
+    """
+    b = f.read(1)
+    if not b:
+        raise EOFError
+    if b[0] != 0xa2:
+        raise ValueError('Expected outer map 0xa2, got 0x%02x' % b[0])
+    if f.read(4) != b'\x63\x73\x65\x71':
+        raise ValueError('Expected seq key')
+    hdr = f.read(1)
+    if not hdr:
+        raise EOFError
+    if hdr[0] == 0x1a:
+        seq_bytes = f.read(4)
+        if len(seq_bytes) < 4:
+            raise EOFError
+    elif hdr[0] == 0x1b:
+        seq_bytes = f.read(8)
+        if len(seq_bytes) < 8:
+            raise EOFError
+    else:
+        raise ValueError('Unexpected seq encoding: 0x%02x' % hdr[0])
+    if f.read(5) != b'\x64\x64\x61\x74\x61':
+        raise ValueError('Expected data key')
+    bs = f.read(1)
+    if not bs:
+        raise EOFError
+    ai = bs[0] & 0x1f
+    if ai <= 23:
+        length = ai
+    elif ai == 24:
+        lb = f.read(1)
+        if not lb:
+            raise EOFError
+        length = lb[0]
+    elif ai == 25:
+        lb = f.read(2)
+        if len(lb) < 2:
+            raise EOFError
+        length = struct.unpack('>H', lb)[0]
+    elif ai == 26:
+        lb = f.read(4)
+        if len(lb) < 4:
+            raise EOFError
+        length = struct.unpack('>I', lb)[0]
+    else:
+        raise ValueError('Unsupported length encoding: %d' % ai)
+    data = f.read(length)
+    if len(data) < length:
+        raise EOFError
+    if not data:
+        return None  # empty placeholder record, caller should skip
+    return data
 
 
 def _safe_getmtime(path: str) -> float:
@@ -110,19 +180,28 @@ class LatestRawFileHandler(FileSystemEventHandler):
 
         while True:
             try:
-                # Decode CBOR object from a **single line**
-                row = cbor2.load(self.latest_file_obj)  # Load the next CBOR object
+                # Use manual reader instead of cbor2.load() to avoid the cbor2
+                # C extension reading in 4096-byte chunks, which causes it to
+                # skip most records regardless of their actual size.
+                data_bytes = _read_raw_record(self.latest_file_obj)
+                if data_bytes is None:
+                    self.last_pos = self.latest_file_obj.tell()
+                    continue  # empty placeholder record
+
+                decoded_data = cbor2.loads(data_bytes)
                 one_minute_ago = datetime.now() - timedelta(minutes=2)
 
-                if 'data' in row:  # Check if 'data' key exists
-                    decoded_data = cbor2.loads(row['data'])
-                    if decoded_data['type'] != 'piezo-dual':
-                        continue
-                    record_time = datetime.fromtimestamp(decoded_data['ts'])
-                    if one_minute_ago > record_time:
-                        continue
-                    load_piezo_row(decoded_data, 'right')
-                    piezo_record_queue.put(decoded_data)
+                if not isinstance(decoded_data, dict) or decoded_data.get('type') != 'piezo-dual':
+                    self.last_pos = self.latest_file_obj.tell()
+                    continue
+
+                record_time = datetime.fromtimestamp(decoded_data['ts'])
+                if one_minute_ago > record_time:
+                    self.last_pos = self.latest_file_obj.tell()
+                    continue
+
+                load_piezo_row(decoded_data, 'right')
+                piezo_record_queue.put(decoded_data)
 
                 # Update last read position
                 self.last_pos = self.latest_file_obj.tell()
@@ -131,7 +210,9 @@ class LatestRawFileHandler(FileSystemEventHandler):
                 # No more CBOR objects to read
                 break
             except Exception as e:
-                logger.error(f"Error decoding CBOR: {e}")
+                logger.error(f"Error reading record: {e}")
+                # Seek back to last known good position to avoid cascading errors
+                self.latest_file_obj.seek(self.last_pos)
                 break
 
 


### PR DESCRIPTION
## Problem

Biometrics produce **no vitals data on Pod 5** due to two separate bugs in `load_raw_files.py` and `stream.py`.

---

## Bug 1: `cbor2.load(f)` skips nearly every record

When the `_cbor2` C extension is installed (the default when cbor2 is pip-installed with a compiler available), `cbor2.load(f)` reads files in **internal 4096-byte chunks**. Each call advances `f.tell()` by 4096 bytes regardless of how large the actual CBOR record was.

RAW file records are typically 17–5000 bytes each. This means only **one record per 4096-byte block** is decoded — all others are silently skipped. On Pod 5, `piezo-dual` records are ~2700 bytes, so the stream sees almost no data. On Pod 3/4 with larger records (~5000 bytes across 4 sensors), the effect is smaller but accuracy is still degraded.

**Before (both files):**
```python
row = cbor2.load(f)          # f.tell() jumps by 4096 regardless of record size
decoded_data = cbor2.loads(row['data'])
```

**After:**
```python
data_bytes = _read_raw_record(f)   # f.tell() advances by exact record size
decoded_data = cbor2.loads(data_bytes)
```

`_read_raw_record(f)` manually parses the outer `{seq: uint, data: bytes}` CBOR wrapper byte-by-byte using `f.read()`, keeping the file position accurate.

---

## Bug 2: Empty placeholder records raise `EOFError` mid-file, stopping the loop early

Pod 5 firmware writes placeholder records with `data = b''` (CBOR byte `0x40` = empty byte string) as sequence number markers between real data records. Calling `cbor2.loads(b'')` raises `CBORDecodeEOF`, which is a **subclass of `EOFError`**.

Both files catch `EOFError` to detect end-of-file and `break` the read loop. So any placeholder record mid-file terminates the entire read — even with megabytes of valid data remaining.

**Fix:** `_read_raw_record()` returns `None` for empty data; callers `continue`.

---

## Additional fix in `stream.py`

The original `except Exception` handler called `break`, leaving `f.tell()` at an unknown position. Changed to `seek(last_pos)` before breaking so the next poll cycle starts from the last known good position.

---

## Files changed

- `biometrics/load_raw_files.py` — added `import struct`, added `_read_raw_record()`, replaced `cbor2.load()` call
- `biometrics/stream/stream.py` — added `import struct`, added `_read_raw_record()`, rewrote `follow_latest_file()` read loop

---

## Tested on

- **Device:** Eight Sleep Pod 5
- **cbor2:** 5.6.5 with `_cbor2` C extension active
- **Python:** 3.10

**Result:** 846 vitals rows (heart rate, HRV, breathing rate) and 400 movement rows recorded in a single night. Stream runs stably with no OOM kills or error floods.

---

## Backward compatibility

The fix is fully compatible with Pod 3/4. The outer `{seq, data}` CBOR format is identical across all pod versions. Pod 3/4 records with `left2`/`right2` fields are unaffected — inner record decoding is unchanged. Pod 3/4 may also see improved accuracy as more records are now correctly decoded.