### PR TITLE
[codex] Allow DNS for NTP while blocking WAN

### DIFF
--- a/scripts/block_internet_access.sh
+++ b/scripts/block_internet_access.sh
@@ -2,6 +2,38 @@
 
 echo "Blocking internet access..."
 
+allow_dns_to_configured_resolvers() {
+  if [ ! -f /etc/resolv.conf ]; then
+    echo "No /etc/resolv.conf found; skipping DNS firewall allowances."
+    return
+  fi
+
+  echo "Allowing DNS traffic to configured resolvers..."
+  while read -r keyword resolver _; do
+    if [ "$keyword" != "nameserver" ] || [ -z "$resolver" ]; then
+      continue
+    fi
+
+    case "$resolver" in
+      *:*)
+        ip6tables -A OUTPUT -d "$resolver" -p udp --dport 53 -j ACCEPT
+        ip6tables -A INPUT -s "$resolver" -p udp --sport 53 -j ACCEPT
+        ip6tables -A OUTPUT -d "$resolver" -p tcp --dport 53 -j ACCEPT
+        ip6tables -A INPUT -s "$resolver" -p tcp --sport 53 -j ACCEPT
+        ;;
+      *.*)
+        iptables -A OUTPUT -d "$resolver" -p udp --dport 53 -j ACCEPT
+        iptables -A INPUT -s "$resolver" -p udp --sport 53 -j ACCEPT
+        iptables -A OUTPUT -d "$resolver" -p tcp --dport 53 -j ACCEPT
+        iptables -A INPUT -s "$resolver" -p tcp --sport 53 -j ACCEPT
+        ;;
+      *)
+        echo "Skipping unrecognized resolver address: $resolver"
+        ;;
+    esac
+  done < /etc/resolv.conf
+}
+
 # IPv4 Rules
 echo "Configuring IPv4 rules..."
 
@@ -47,6 +79,8 @@ iptables -A OUTPUT -d 172.16.0.0/12 -j ACCEPT
 # Allow LAN traffic Class C (192.168.0.0/16)
 iptables -A INPUT -s 192.168.0.0/16 -j ACCEPT
 iptables -A OUTPUT -d 192.168.0.0/16 -j ACCEPT
+
+allow_dns_to_configured_resolvers
 
 # Allow NTP traffic - this allows us to synchronize the system time
 iptables -I OUTPUT -p udp --dport 123 -j ACCEPT
@@ -95,4 +129,3 @@ ip6tables -A OUTPUT -j DROP
 ip6tables-save > /etc/iptables/ip6tables.rules
 
 echo "Blocked WAN internet access successfully!"
-

--- a/scripts/unblock_internet_access.sh
+++ b/scripts/unblock_internet_access.sh
@@ -7,4 +7,9 @@ iptables -X
 iptables -t nat -F
 iptables -t nat -X
 
+ip6tables -F
+ip6tables -X
+ip6tables -t nat -F 2>/dev/null || true
+ip6tables -t nat -X 2>/dev/null || true
+
 echo "Unblocked internet access!"


### PR DESCRIPTION
## Summary
- Allow DNS traffic to the resolvers listed in `/etc/resolv.conf` while WAN blocking is enabled.
- Keep `systemd-timesyncd` able to resolve NTP hostnames such as `pool.ntp.org` after `block_internet_access.sh` applies final DROP rules.
- Flush IPv6 firewall rules in `unblock_internet_access.sh` so reapplying the block script does not leave stale IPv6 DROP rules ahead of the new DNS allowances.

## Root Cause
The block script already allowed UDP/123 for NTP, but `timesyncd` uses hostnames. On an affected pod, `/etc/resolv.conf` pointed at DNS resolvers like `50.0.1.1` and `50.0.2.2`. Those resolvers were outside the LAN allow ranges, so DNS traffic was dropped before `timesyncd` could resolve `pool.ntp.org`.

The result was:
- `nslookup pool.ntp.org` failed under the blocked firewall rules.
- `timedatectl` reported `System clock synchronized: no`.
- The RTC remained stale, increasing the chance that scheduling starts from a bad restored timestamp after reboot or power loss.

During live testing, I also found `unblock_internet_access.sh` only flushed IPv4 rules. That meant old IPv6 DROP rules could remain in place and appear before newly added IPv6 DNS allowances when the block script was rerun.

## Implementation Notes
`block_internet_access.sh` now reads `/etc/resolv.conf` and allows DNS to each configured `nameserver`:
- IPv4 and IPv6 are handled separately.
- UDP and TCP port 53 are allowed.
- The rules are inserted before the final IPv4 and IPv6 DROP rules.

`unblock_internet_access.sh` now clears IPv6 filter rules too, and best-effort clears IPv6 NAT rules where supported.

## Validation
Local checks:
- `bash -n scripts/block_internet_access.sh`
- `bash -n scripts/unblock_internet_access.sh`

Live pod validation on a Pod 3 running Free Sleep `2.1.5`:
- Installed this PR's patched `block_internet_access.sh` and `unblock_internet_access.sh` over the `2.1.5` install.
- Ran the patched `unblock_internet_access.sh`, then the patched `block_internet_access.sh`.
- Confirmed IPv4 DNS allow rules for `50.0.1.1` and `50.0.2.2` are before the final IPv4 DROP.
- Confirmed IPv6 DNS allow rules for the configured IPv6 resolvers are before the final IPv6 DROP.
- Confirmed `nslookup pool.ntp.org` resolves successfully while WAN blocking is active.
- Confirmed `timedatectl` reports `System clock synchronized: yes` and the RTC has a current 2026 timestamp.
- Confirmed `/api/deviceStatus` reports `freeSleep.version` as `2.1.5`.
- Confirmed `/api/serverStatus` shows jobs, power schedule, temperature schedule, Franken socket, and Franken monitor healthy after reconnect.
