### PR TITLE
Fix sleep analyzer loop on partial CBOR tail

### DIFF
--- a/biometrics/load_raw_files.py
+++ b/biometrics/load_raw_files.py
@@ -105,7 +105,10 @@ def _decode_cbor_file(file_path: str, data: dict, start_time, end_time, side: Si
                 ).strftime("%Y-%m-%d %H:%M:%S")
                 data[decoded_data['type']].append(decoded_data)
 
-            except EOFError:
+            # The active RAW segment can end in a partially written CBOR item.
+            # cbor2 reports that as CBORDecodeEOF (not Python's EOFError); both
+            # mean there is no more complete data available in this snapshot.
+            except (EOFError, cbor2.CBORDecodeEOF):
                 break
             except Exception as error:
                 logger.error(error)


### PR DESCRIPTION
## Summary

- treat `cbor2.CBORDecodeEOF` as end-of-file while scanning RAW segments
- retain the existing `EOFError` behavior
- document why an active RAW segment can end with a partial CBOR item

## Problem

The sleep analyzer can read the RAW segment that is currently being written. A partial final CBOR item raises `CBORDecodeEOF`, which is not a subclass of Python `EOFError`. The generic exception handler logs it and retries without advancing the file position, creating a tight error loop and leaving the analyzer health stuck at `started`.

Observed on Free Sleep 2.1.5 with repeated `premature end of stream` messages. Applying this change on a Pod allowed both calibration jobs and both sleep analyzers to complete healthy and insert sleep records.

## Validation

- `python3 -m py_compile biometrics/load_raw_files.py`
- live Pod: left and right analyzer jobs completed successfully after the patch